### PR TITLE
강의실 스토어에 참가자 관리 정보 추가

### DIFF
--- a/apps/frontend/src/feature/room/stores/useRoomStore.ts
+++ b/apps/frontend/src/feature/room/stores/useRoomStore.ts
@@ -27,7 +27,6 @@ interface RoomActions {
   removeProducer: (participantId: string, type: MediaType) => void;
   getParticipantList: () => Participant[];
   getParticipant: (id: string) => Participant | undefined;
-  leaveRoom: () => void;
 
   reset: () => void;
 }
@@ -135,9 +134,6 @@ export const useRoomStore = create<RoomState>()(
           const participants = get().participants;
           return participants.get(id);
         },
-
-        /** 참가자 목록과 미디어 설정만 초기화 (내 정보 유지) */
-        leaveRoom: () => set({ participants: new Map(), routerRtpCapabilities: null }),
 
         /** 스토어 초기화 */
         reset: () => set({ ...initialState, participants: new Map() }),


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 관련된 이슈 번호를 작성하고, 자동으로 이슈를 닫으려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #124 

<br />

## ⏰ 작업 시간

> 예상 작업 시간과 실제 작업 시간을 작성해주세요.  
> 두 시간이 다를 경우, 그 이유를 함께 설명해주세요.

- 예상 작업 시간 : 1 h
- 실제 작업 시간 : 1 h

<br />

## 📝 작업 내용

> 이번 PR(작업)을 통해 수행한 주요 내용을 구체적으로 작성해주세요.

- `routerRtpCapabilities`를 RoomState에 추가하고, 설정을 위한 `setRouterRtpCapabilities` 액션을 정의했습니다.

- 참가자 정보를 관리하기 위한 `participants: Map<string, Participant>` 상태를 추가했습니다.

- 참가자 추가/삭제, 참가자의 프로듀서 추가/삭제, 참가자 단일 조회/목록 조회, 스토어 초기화(reset) 액션을 구현했습니다.

<br />

> 상태

| 상태 이름                 | 타입                       | 설명                                                       |
| --------------------- | ------------------------ | -------------------------------------------------------- |
| myInfo                | MyInfo \| null           | 현재 접속한 나의 아이디, 이름, 역할 정보를 담습니다.                  |
| routerRtpCapabilities | RtpCapabilities \| null  | mediasoup 라우터로부터 전달받은 RTP Capabilities 정보를 보관합니다.|
| participants          | Map<string, Participant> | 참가자 id를 key로 가지는 참가자 정보 컬렉션입니다.                  |
| actions               | RoomActions              | RoomStore 상태를 변경/조회하기 위한 메서드 집합입니다.              |

| 타입 이름       | 필드                                                          | 설명                                                  |
| ----------- | ----------------------------------------------------------- | --------------------------------------------------- |
| MyInfo      | id, name, role                                              | 나의 기본 정보와 역할을 나타냅니다.                         |
| Participant | id, name, role, joinedAt, producers: Map<MediaType, string> | 참가자 식별 정보, 입장 시각, 미디어 타입별 producerId를 관리합니다. |

<br />

> 액션

| 액션 이름                    | 시그니처                                                                 | 설명                                                         |
| ------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------- |
| setMyInfo                | (info: MyInfo) => void                                               | 나의 기본 정보를 설정합니다.                                   |
| setRouterRtpCapabilities | (capabilities: RtpCapabilities) => void                              | 라우터 RTP Capabilities를 스토어에 저장합니다.                  |
| addParticipant           | (data: UserJoinedPayload) => void                                    | 새로 입장한 참가자를 participants 맵에 추가합니다.                 |
| removeParticipant        | (participantId: string) => void                                      | 특정 참가자를 participants에서 제거합니다.                      |
| addProducer              | (participantId: string, type: MediaType, producerId: string) => void | 참가자의 producers 맵에 주어진 타입의 producerId를 등록합니다.       |
| removeProducer           | (participantId: string, type: MediaType) => void                     | 참가자의 producers 맵에서 해당 타입의 producer를 제거합니다.         |
| getParticipantList       | () => Participant[]                                                  | 참가자 목록을 배열 형태로 반환합니다.                              |
| getParticipant           | (id: string) => Participant \| undefined                             | id에 해당하는 단일 참가자 정보를 반환합니다.                         |
| reset                    | () => void                                                           | 초기 상태로 스토어를 완전히 리셋하고 participants를 빈 Map으로 초기화합니다. |

<br />

> 

> 관련된 스크린샷이나 캡처 화면을 첨부해주세요.

<br />

## 🪏 주요 고민과 해결 과정

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### useRoomStore 와 useMediaStore 의 관계

우선, `useRoomStore`는 강의실 도메인에서 다뤄지는 데이터를 관리하는 스토어로, 내 정보와 참가자 목록 같은 참가자 메타데이터를 관리합니다.
​
반대로 `useMediaStore`는 미디어 장치 및 스트림과 같이 실제 미디어 처리에 가까운 상태를 관리하도록 분리했습니다.

<br />

참가자 정보와 미디어 스트림 모두 참가자와 연관되어 있기 때문에, `useRoomStore.participants`에 스트림까지 함께 넣을지, 혹은 `useMediaStore.remoteStreams`에서 따로 관리할지에 대한 고민이 있었습니다.

<br />
​
결과적으로 “참가자 도메인 정보”와 “스트림/장치 도메인 정보”를 분리하는 편이 역할이 더 명확하다고 판단해, 아래와 같이 책임을 나누었습니다.

<br />

| 항목    | useRoomStore.participants    | useMediaStore.remoteStreams |
| ----- | ---------------------------- | --------------------------- |
| 목적    | 참가자 메타데이터 관리                 | 참가자의 실제 미디어 스트림 관리          |
| 키     | participantId                | consumerId                  |
| 저장 내용 | 이름, 역할, 입장 시간, producerId 목록 | 실제 MediaStream 객체           |

<br />

> participants (useRoomStore): “누가 방에 있고, 어떤 미디어를 송출 중인지”를 표현하는 정보

```tsx
interface Participant {
  id: string;
  name: string;           // "홍길동"
  role: ParticipantRole;  // "host" | "guest"
  joinedAt: Date;
  producers: Map<MediaType, string>;  // { audio: "prod-123", video: "prod-456" }
}
```

<br />

> remoteStreams (useMediaStore): “현재 내가 수신해서 재생할 수 있는 실제 스트림”을 담는 컬렉션

```tsx
interface RemoteStream {
  participantId: string;
  stream: MediaStream;    // 실제 비디오/오디오 데이터
  type: MediaType;
  consumerId: string;
}
```

간단히 말해, `participants`는 “누가 무엇을 보내고 있는지”를 표현하고, `remoteStreams`는 “내가 실제로 받아서 화면/스피커에 재생할 스트림”을 관리하는 계층이라고 이해해주시면 좋겠습니다.

<br />

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 참고한 문서, 링크, 또는 외부 리소스를 작성해주세요.
