### PR TITLE
feat: 강의실 입장 시 기존에 입장해 있는 참가자 정보 반환

### DIFF
--- a/apps/backend/src/room/room.controller.spec.ts
+++ b/apps/backend/src/room/room.controller.spec.ts
@@ -209,6 +209,7 @@ describe('RoomController', () => {
             { producerId: 'v1', participantId: 'user1', kind: 'video', type: 'video' },
           ],
         },
+        participants: [{ id: 'user1', name: 'user1', role: 'presenter', joinedAt: new Date() }],
       };
 
       mockRoomService.joinRoom = jest.fn().mockResolvedValue(expectedResponse);

--- a/apps/backend/src/room/room.gateway.ts
+++ b/apps/backend/src/room/room.gateway.ts
@@ -136,9 +136,9 @@ export class RoomGateway implements OnGatewayDisconnect {
       }
 
       this.logger.log(`✅ [join_room] ${participant.name}님이 ${roomId} 강의실에 입장했습니다.`);
-      const mediasoup = await this.roomService.getRoomInfo(roomId, participant);
+      const roomInfo = await this.roomService.getRoomInfo(roomId, participant);
 
-      return { success: true, mediasoup };
+      return { success: true, ...roomInfo };
     } catch (error) {
       this.logger.error(`❌ [join_room] 실패:`, error);
       return { success: false, error: '강의실 입장에 실패했습니다.' };

--- a/packages/shared-interfaces/src/api.ts
+++ b/packages/shared-interfaces/src/api.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { createLectureSchema, enterLectureSchema } from './room.js';
 import { nicknameValidate, ParticipantRole } from './participant.js';
-import { MediasoupRoomInfo } from './shared.js';
+import { RoomInfo } from './shared.js';
 
 /**
  * 강의실 생성 요청
@@ -17,14 +17,13 @@ export interface ErrorResponse {
 /**
  * 강의실 생성 응답
  */
-export interface CreateRoomResponse {
+export interface CreateRoomResponse extends RoomInfo {
   roomId: string;
   host: {
     id: string;
     name: string;
     role: ParticipantRole;
   };
-  mediasoup: MediasoupRoomInfo;
 }
 
 export type EnterLectureRequestBody = z.infer<typeof enterLectureSchema>;
@@ -42,11 +41,10 @@ export interface EnterRoomRequest {
 /**
  * 강의실 입장 응답
  */
-export interface EnterRoomResponse {
+export interface EnterRoomResponse extends RoomInfo {
   participantId: string;
   name: string;
   role: ParticipantRole;
-  mediasoup: MediasoupRoomInfo;
 }
 
 /**

--- a/packages/shared-interfaces/src/participant.ts
+++ b/packages/shared-interfaces/src/participant.ts
@@ -27,6 +27,13 @@ export interface Participant {
   joinedAt: string;
 }
 
+export interface ParticipantPayload {
+  id: string;
+  name: string;
+  role: string;
+  joinedAt: Date;
+}
+
 export const nicknameValidate = z.object({
   nickname: z
     .string()

--- a/packages/shared-interfaces/src/shared.ts
+++ b/packages/shared-interfaces/src/shared.ts
@@ -1,7 +1,14 @@
+import { ParticipantPayload } from './participant.js';
+
 export type Status = 'pending' | 'active' | 'ended';
 export type MediaKind = 'audio' | 'video'; // mediasoup에서 사용하는 미디어 타입
 export type MediaType = MediaKind | 'screen'; // 우리가 사용할 미디어 소스 타입
 export type ToggleActionType = 'pause' | 'resume';
+
+export interface RoomInfo {
+  mediasoup: MediasoupRoomInfo;
+  participants: ParticipantPayload[];
+}
 
 export interface MediasoupRoomInfo {
   routerRtpCapabilities: unknown;

--- a/packages/shared-interfaces/src/socket.ts
+++ b/packages/shared-interfaces/src/socket.ts
@@ -1,11 +1,5 @@
-import { ParticipantRole } from './participant.js';
-import {
-  MediaKind,
-  MediasoupProducer,
-  MediasoupRoomInfo,
-  MediaType,
-  ToggleActionType,
-} from './shared.js';
+import { ParticipantPayload, ParticipantRole } from './participant.js';
+import { MediaKind, MediasoupProducer, MediaType, RoomInfo, ToggleActionType } from './shared.js';
 
 // 제스처 타입 정의
 export type GestureType =
@@ -77,10 +71,9 @@ export interface BaseResponse {
 
 export type JoinRoomResponse =
   | (BaseResponse & { success: false })
-  | {
+  | ({
       success: true;
-      mediasoup: MediasoupRoomInfo;
-    };
+    } & RoomInfo);
 
 export type CreateTransportResponse<T1 = any, T2 = any, T3 = any> =
   | (BaseResponse & { success: false })
@@ -130,12 +123,7 @@ export type LeaveRoomResponse = BaseResponse;
 export type BreakRoomResponse = BaseResponse;
 
 // 서버에서 보내는 브로드캐스트 페이로드
-export interface UserJoinedPayload {
-  id: string;
-  name: string;
-  role: string;
-  joinedAt: Date;
-}
+export type UserJoinedPayload = ParticipantPayload;
 
 export interface UserLeftPayload {
   id: string;


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 관련된 이슈 번호를 작성하고, 자동으로 이슈를 닫으려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #164 

<br />

## ⏰ 작업 시간

> 예상 작업 시간과 실제 작업 시간을 작성해주세요.  
> 두 시간이 다를 경우, 그 이유를 함께 설명해주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h

<br />

## 📝 작업 내용

> 이번 PR(작업)을 통해 수행한 주요 내용을 구체적으로 작성해주세요.

기존에는 접속한 참가자가 기존 참가자 정보 중 producer 정보는 받아오지만, 어떤 사람들이 들어와있는지 정보를 확인할 수 없었었습니다.

이를 해결하기 위해 추가적으로 participant 정보를 반환하게 만들어 프론트엔드에서 화면에 해당 참가자 정보를 유지할 수 있도록 합니다.

<br />

> 관련된 스크린샷이나 캡처 화면을 첨부해주세요.

<br />

## 🪏 주요 고민과 해결 과정

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

<br />

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

@KimDongGyun23 말씀하신 작업을 완료했습니다. 한번 확인해주세요!!!

<br />

## 📘 참고 자료

> 참고한 문서, 링크, 또는 외부 리소스를 작성해주세요.
