### PR TITLE
fix: event emitter 이벤트 와일드 카드 문제 해결

### DIFF
--- a/apps/backend/src/redis/redis.service.ts
+++ b/apps/backend/src/redis/redis.service.ts
@@ -62,7 +62,7 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
 
         this.logger.debug(`[Redis Expired] Prefix: ${prefix}, Key: ${key}`);
 
-        this.eventEmitter.emit(`redis.expired.${key}`, key);
+        this.eventEmitter.emit(`redis.expired.${prefix}`, key);
       }
     });
 

--- a/apps/backend/src/redis/repository-manager/poll-manager.service.ts
+++ b/apps/backend/src/redis/repository-manager/poll-manager.service.ts
@@ -316,7 +316,7 @@ export class PollManagerService extends BaseRedisRepository<Poll> {
     return poll.options;
   }
 
-  @OnEvent('redis.expired.*')
+  @OnEvent('redis.expired.poll')
   async handlePollAutoClose(key: string) {
     const parts = key.split(':');
     if (parts[0] !== 'poll') return;

--- a/apps/backend/src/redis/repository-manager/qna-manager.service.ts
+++ b/apps/backend/src/redis/repository-manager/qna-manager.service.ts
@@ -258,7 +258,7 @@ export class QnaManagerService extends BaseRedisRepository<Qna> {
     return qna.answers;
   }
 
-  @OnEvent('redis.expired.qna:*')
+  @OnEvent('redis.expired.qna')
   async handleQnaAutoClose(key: string) {
     const parts = key.split(':');
 

--- a/apps/backend/src/room/room.gateway.ts
+++ b/apps/backend/src/room/room.gateway.ts
@@ -458,7 +458,7 @@ export class RoomGateway implements OnGatewayConnection, OnGatewayDisconnect {
     this.socketMetadataService.delete(socket.id);
   }
 
-  @OnEvent('redis.expired.reconnect:pending:*')
+  @OnEvent('redis.expired.reconnect')
   async handleReconnectExpired(key: string) {
     const participantId = key.split(':').pop();
     const metadata = await this.participantManagerService.popReconnectMetadata(participantId!);


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 관련된 이슈 번호를 작성하고, 자동으로 이슈를 닫으려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #196 

<br />

## ⏰ 작업 시간

> 예상 작업 시간과 실제 작업 시간을 작성해주세요.  
> 두 시간이 다를 경우, 그 이유를 함께 설명해주세요.

- 예상 작업 시간 : 1h
- 실제 작업 시간 : 1h

<br />

## 📝 작업 내용

> 이번 PR(작업)을 통해 수행한 주요 내용을 구체적으로 작성해주세요.

event emitter를 도입하고, 와일드 카드를 이용해 이벤트를 수신하고 있었습니다. 이벤트 구분자는 `.`로 설정한 상태였는데 특정 이벤트의 경우 와일드 카드를 `:`로 구분된 부분에 사용하였습니다. (`redis.expried.reconnect:pending:*`) 

이러한 경우 `redis.expried.reconnect:pending:.*`인 이벤트를 찾기 떄문에 이벤트 수신이 되지 않는 문제가 있었습니다. 그래서 와일드 카드를 제거하고, redis 이벤트를 `prefix` 단위로 발생시키도록 하여 함수에서 key를 통해 수신할 수 있도록 수정하였습니다.

<br />

> 관련된 스크린샷이나 캡처 화면을 첨부해주세요.

<br />

## 🪏 주요 고민과 해결 과정

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

- [트러블 슈팅1](링크)

<br />

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 참고한 문서, 링크, 또는 외부 리소스를 작성해주세요.
