### PR TITLE
fix: 미디어 상태 변경 시 원격 producer에 대한 resume 처리 추가

### DIFF
--- a/apps/frontend/src/feature/room/mediasoup/MediaRoomManager.ts
+++ b/apps/frontend/src/feature/room/mediasoup/MediaRoomManager.ts
@@ -51,8 +51,11 @@ export class MediaRoomManager {
 
     // 미디어 상태 변경 처리
     this.socket.on('media_state_changed', (data) => {
+      logger.media.info(`[Room] 미디어 상태 변경: (${data.type}) - ${data.action}`);
       if (data.action === 'pause') {
         this.actions.media.removeRemoteStreamByParticipant(data.participantId, data.type);
+      } else if (data.action === 'resume') {
+        this.actions.controls.consumeRemoteProducer(data);
       }
     });
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 관련된 이슈 번호를 작성하고, 자동으로 이슈를 닫으려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #233 

<br />

## ⏰ 작업 시간

> 예상 작업 시간과 실제 작업 시간을 작성해주세요.  
> 두 시간이 다를 경우, 그 이유를 함께 설명해주세요.

- 예상 작업 시간 : 1 h
- 실제 작업 시간 : 0.5 h

<br />

## 📝 작업 내용

> 이번 PR(작업)을 통해 수행한 주요 내용을 구체적으로 작성해주세요.

- 서버에서 미디어 상태 변경 알림이 왔을 때, `resume` 하는 로직을 추가하였습니다.

<br />

> 관련된 스크린샷이나 캡처 화면을 첨부해주세요.

<br />

## 🪏 주요 고민과 해결 과정

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

<br />

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 참고한 문서, 링크, 또는 외부 리소스를 작성해주세요.
