### PR TITLE
chore: 보안 설정 강화 및 키 만료 이벤트 누락 이슈 해결

### DIFF
--- a/.github/deployments/redis/docker-compose.yml
+++ b/.github/deployments/redis/docker-compose.yml
@@ -16,10 +16,15 @@ services:
       - redis-data:/data
     command: >
       redis-server
+      --requirepass "${REDIS_PASSWORD}"
       --appendonly yes
       --appendfsync everysec
       --maxmemory ${REDIS_MAXMEMORY:-256mb}
       --maxmemory-policy volatile-lru
+      --notify-keyspace-events Ex
+      --rename-command FLUSHALL ""
+      --rename-command FLUSHDB ""
+      --rename-command CONFIG ""
     networks:
       - redis-network
     healthcheck:
@@ -38,6 +43,7 @@ services:
       - "${REDIS_EXPORTER_PORT:-9121}:9121"
     environment:
       - REDIS_ADDR=redis:6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
     depends_on:
       - redis # Redis 컨테이너가 먼저 시작되어야 함
     networks:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,12 +55,13 @@ jobs:
           AWS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
           AWS_SECRET: ${{ secrets.AWS_S3_SECRET_KEY }}
           AWS_BUCKET: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD_DEV }}
         with:
           host: ${{ secrets.NCP_DEV_HOST }}
           username: ${{ secrets.NCP_DEV_USERNAME }}
           key: ${{ secrets.NCP_DEV_SSH_KEY }}
           port: ${{ secrets.NCP_DEV_PORT || 22 }}
-          envs: DOCKER_USERNAME,TAG,FE_URL,AWS_REGION,AWS_KEY,AWS_SECRET,AWS_BUCKET
+          envs: DOCKER_USERNAME,TAG,FE_URL,AWS_REGION,AWS_KEY,AWS_SECRET,AWS_BUCKET,REDIS_PASSWORD
           script: |
             DEPLOY_BRANCH="${{ needs.prepare.outputs.branch }}"
             echo "배포 브랜치: ${DEPLOY_BRANCH}"
@@ -104,6 +105,7 @@ jobs:
             update_env "REDIS_HOST" "${{ secrets.NCP_DEV_REDIS_HOST }}"
             update_env "REDIS_PORT" "${{ secrets.NCP_DEV_REDIS_PORT }}"
             update_env "ANNOUNCED_IP" "${{ secrets.NCP_DEV_HOST }}"
+            update_env "REDIS_PASSWORD" "${REDIS_PASSWORD}"
 
             # 기존 컨테이너 중지 및 제거 (포트 충돌 방지)
             docker compose -f docker-compose.yml -f docker-compose.develop.yml down || true
@@ -145,12 +147,13 @@ jobs:
           AWS_KEY: ${{ secrets.AWS_S3_ACCESS_KEY }}
           AWS_SECRET: ${{ secrets.AWS_S3_SECRET_KEY }}
           AWS_BUCKET: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD_PROD }}
         with:
           host: ${{ secrets.NCP_PROD_HOST }}
           username: ${{ secrets.NCP_PROD_USERNAME }}
           key: ${{ secrets.NCP_PROD_SSH_KEY }}
           port: ${{ secrets.NCP_PROD_PORT || 22 }}
-          envs: DOCKER_USERNAME,TAG,FE_URL,AWS_REGION,AWS_KEY,AWS_SECRET,AWS_BUCKET
+          envs: DOCKER_USERNAME,TAG,FE_URL,AWS_REGION,AWS_KEY,AWS_SECRET,AWS_BUCKET,REDIS_PASSWORD
           script: |
             DEPLOY_BRANCH="${{ needs.prepare.outputs.branch }}"
             echo "배포 브랜치: ${DEPLOY_BRANCH}"
@@ -193,6 +196,7 @@ jobs:
             update_env "REDIS_HOST" "${{ secrets.NCP_PROD_REDIS_HOST }}"
             update_env "REDIS_PORT" "${{ secrets.NCP_PROD_REDIS_PORT }}"
             update_env "ANNOUNCED_IP" "${{ secrets.NCP_PROD_HOST }}"
+            update_env "REDIS_PASSWORD" "${REDIS_PASSWORD}"
 
             # 기존 컨테이너 중지 및 제거 (포트 충돌 방지)
             docker compose -f docker-compose.yml -f docker-compose.prod.yml down || true
@@ -273,14 +277,15 @@ jobs:
             # 환경 변수 설정
             echo "CONTAINER_PREFIX=plum-dev" > .env
             echo "REDIS_MAXMEMORY=1gb" >> .env
-
+            echo "REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD_DEV }}" >> .env
+            
             # 컨테이너 재시작
             docker compose pull
             docker compose up -d
 
             # 헬스체크
             sleep 5
-            docker exec plum-dev-redis redis-cli ping || echo "Redis health check failed"
+            docker exec plum-dev-redis redis-cli -a "${{ secrets.REDIS_PASSWORD_DEV }}" ping || echo "Redis health check failed"
 
             # 상태 확인
             docker compose ps
@@ -418,12 +423,14 @@ jobs:
             # 환경 변수 설정 (Prod는 메모리 2GB)
             echo "CONTAINER_PREFIX=plum-prod" > .env
             echo "REDIS_MAXMEMORY=2gb" >> .env
+            echo "REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD_PROD }}" >> .env
+
 
             docker compose pull
             docker compose up -d
 
             sleep 5
-            docker exec plum-prod-redis redis-cli ping || echo "Redis health check failed"
+            docker exec plum-prod-redis redis-cli -a "${{ secrets.REDIS_PASSWORD_PROD }}" ping || echo "Redis health check failed"
 
             docker compose ps
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -10,7 +10,12 @@ services:
     container_name: redis-local
     ports:
       - "6379:6379"
-    command: redis-server --appendonly yes
+    command: redis-server
+      --appendonly yes
+      --appendfsync everysec
+      --maxmemory ${REDIS_MAXMEMORY:-256mb}
+      --maxmemory-policy volatile-lru
+      --notify-keyspace-events Ex
     volumes:
       - redis-data:/data
     networks:


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 관련된 이슈 번호를 작성하고, 자동으로 이슈를 닫으려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #185

<br />

## ⏰ 작업 시간

> 예상 작업 시간과 실제 작업 시간을 작성해주세요.  
> 두 시간이 다를 경우, 그 이유를 함께 설명해주세요.

- 예상 작업 시간 : 2h
- 실제 작업 시간 : 1.5h

기존에 방 소실을 확인했을 때 보안 이슈가 있었을 것이라고 생각했고, redis 로그를 디버깅 하면서 예상되는 원인을 금방 찾을 수 있었습니다.

<br />

## 📝 작업 내용

> 이번 PR(작업)을 통해 수행한 주요 내용을 구체적으로 작성해주세요.

이번 작업은 Redis 보안 침해(Cryptojacking 공격) 대응과 투표 마감 이벤트 유실 문제를 해결하기 위해 인프라와 코드를 수정하였습니다.

- Redis 보안 강화 (Docker Compose)
  - requirepass 설정을 통한 비밀번호 인증 단계 추가
  - rename-command를 사용하여 위험 명령어(FLUSHALL, FLUSHDB, CONFIG) 무력화
  - expose 설정을 통해 Redis 포트의 외부 노출 차단 및 내부 네트워크 격리
- Redis Expired 이벤트 복구
  - Redis 실행 옵션에 `--notify-keyspace-events Ex `고정 설정 (재시작 시에도 유지)
  - NestJS 코드에서 런타임에 설정을 시도하던 불안정한 로직 제거
- CI/CD 파이프라인 및 모니터링 연동
  - GitHub Actions를 통한 환경 변수(REDIS_PASSWORD) 자동 주입 로직 추가
  - redis-exporter에 인증 정보를 추가하여 보안 적용 후에도 메트릭 수집 가능하도록 수정
- NCP ACG 방화벽 재설정
  - Redis 서버의 9121, 6379 포트를 특정 IP(백엔드, 모니터링 서버)로만 한정하여 허용

<br />

> 관련된 스크린샷이나 캡처 화면을 첨부해주세요.

<br />

## 🪏 주요 고민과 해결 과정

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.


### 1. 해킹으로 인한 데이터 유실 및 시스템 변조

외부 IP(218.78.131.154)로부터 FLUSHALL 공격을 받아 투표 데이터가 삭제되고, Redis 설정이 해커의 스크립트 실행을 위한 구조로 변조됨.

단순 컨테이너 재시작이 아닌 docker-compose down으로 런타임 설정을 완전히 초기화하고, docker-compose.yml 내에 보안 옵션을 명시적으로 선언하여 영구적인 방어 체계 구축.

### 2. Redis CONFIG 명령어 차단 시 백엔드 초기화 에러
보안을 위해 CONFIG 명령어를 막으면, NestJS의 ioredis 클라이언트가 실행 시점에 설정을 변경하려다 에러가 발생함.

인프라 레벨에서 이미 설정을 마친 상태이므로, 백엔드 코드 내의 this.client.config('SET', ...) 호출부를 제거하여 충돌 방지.

### 3. 보안 적용 후 모니터링 단절 방지
Redis에 패스워드를 걸면 redis-exporter가 데이터를 읽지 못해 Grafana 대시보드가 끊김.

Redis 서버와 같은 네트워크에 있는 Exporter에만 패스워드 환경 변수를 주입하고, 외부 모니터링 서버는 기존처럼 Exporter를 통해 안전하게 데이터를 읽어가도록 설계.

<br />

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 참고한 문서, 링크, 또는 외부 리소스를 작성해주세요.
