### PR TITLE
feat: router simultaneous access

### DIFF
--- a/apps/backend/src/mediasoup/multi-router-manager.service.ts
+++ b/apps/backend/src/mediasoup/multi-router-manager.service.ts
@@ -535,6 +535,7 @@ export class MultiRouterManagerService {
     // Map에서 제거
     this.rooms.delete(roomId);
     this.participantRouterMap.delete(roomId);
+    this.roomFirstJoinTime.delete(roomId); // 버스트 감지용 시간 정보 정리
     this.logger.log(`🗑️  Room ${roomId} 정리 완료`);
   }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 관련된 이슈 번호를 작성하고, 자동으로 이슈를 닫으려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #267 

<br />

## ⏰ 작업 시간

> 예상 작업 시간과 실제 작업 시간을 작성해주세요.  
> 두 시간이 다를 경우, 그 이유를 함께 설명해주세요.

- 예상 작업 시간 : 1.5h
- 실제 작업 시간 : 1.5h

<br />

## 📝 작업 내용

> 이번 PR(작업)을 통해 수행한 주요 내용을 구체적으로 작성해주세요.
 60명 테스트에서 동시 접속시에 하나의 라우터에 몰림 현상이 발생했습니다.
이문제를 해결하기 위해서 버스트전략을 사용했습니다.

<br />

> 관련된 스크린샷이나 캡처 화면을 첨부해주세요.

<br />

## 🪏 주요 고민과 해결 과정

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

10명 이상의 사람들이 점차적으로 접근할때는 늘어나는 수에 비례하며 최대 cpu까지 적당한 분배가 가능합니다.
하지만 2초이내에 동시접속자가 10명이상인 경우에는 그보다 더 많은 인원의 접근이 있다고 생각했습니다.
이때 고민했던 점은 
현재 적용한 동적 계산 버스트를 사용하냐 처음부터 소규모가 아니라는 전제로 라우터를 활성화시키냐였습니다.
후자가 단순하지만 라우터의 낭비를 고민해서 현재의 구조로 만들었기에
2초이내 10명이상의 사용자 접근시 라우터를 활성화시키는 방향으로 구현했습니다.

초반 스파크가 있다고 생각하고 버퍼링 방식으로 수정하려 했으나 근거가 부족했습니다.
8퍼센트가 하나의 라우터에 몰렸다는게 정말 5명 이상의 사람이 하나의 라우터로 접근해서 나온 수치인지 알기 어려웠길래 
지금은 라우터 활성화 까지만으로만 진행했습니다.
<br />

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 참고한 문서, 링크, 또는 외부 리소스를 작성해주세요.
