### PR TITLE
fix: 카메라를 껐다 켤때 원본 배경이 보이는 문제 해결

### DIFF
--- a/apps/frontend/src/feature/room/hooks/useBackgroundEffectCommon.ts
+++ b/apps/frontend/src/feature/room/hooks/useBackgroundEffectCommon.ts
@@ -24,6 +24,31 @@ export type RenderCanvases<T extends HTMLCanvasElement | OffscreenCanvas> = {
   maskCanvas: T;
 };
 
+function drawBackgroundImage(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  background: CanvasImageSource,
+  canvasWidth: number,
+  canvasHeight: number,
+): void {
+  const bgWidth = (background as HTMLImageElement | ImageBitmap).width;
+  const bgHeight = (background as HTMLImageElement | ImageBitmap).height;
+  const imageRatio = bgWidth / bgHeight;
+  const canvasRatio = canvasWidth / canvasHeight;
+  let drawWidth = canvasWidth;
+  let drawHeight = canvasHeight;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  if (imageRatio > canvasRatio) {
+    drawHeight = canvasWidth / imageRatio;
+    offsetY = (canvasHeight - drawHeight) / 2;
+  } else {
+    drawWidth = canvasHeight * imageRatio;
+    offsetX = (canvasWidth - drawWidth) / 2;
+  }
+  ctx.drawImage(background, offsetX, offsetY, drawWidth, drawHeight);
+}
+
 export function renderBackgroundEffect<T extends HTMLCanvasElement | OffscreenCanvas>(
   source: CanvasImageSource,
   background: CanvasImageSource | null,
@@ -42,12 +67,18 @@ export function renderBackgroundEffect<T extends HTMLCanvasElement | OffscreenCa
     return;
   }
 
-  // 마스크가 아직 준비되지 않은 경우 전체 블러 처리 (원본 배경 노출 방지)
+  // 마스크가 아직 준비되지 않은 경우 (원본 배경 노출 방지)
   if (!mask) {
     outputCtx.clearRect(0, 0, width, height);
-    outputCtx.filter = `blur(${BLUR_PX}px)`;
-    outputCtx.drawImage(source, 0, 0, width, height);
-    outputCtx.filter = 'none';
+    if (mode === 'image' && background) {
+      // 이미지 모드: 배경 이미지만 표시 (마스크 준비되면 사람이 합성됨)
+      drawBackgroundImage(outputCtx, background, width, height);
+    } else {
+      // 블러 모드: 전체 블러 처리
+      outputCtx.filter = `blur(${BLUR_PX}px)`;
+      outputCtx.drawImage(source, 0, 0, width, height);
+      outputCtx.filter = 'none';
+    }
     return;
   }
 
@@ -74,23 +105,7 @@ export function renderBackgroundEffect<T extends HTMLCanvasElement | OffscreenCa
   outputCtx.clearRect(0, 0, width, height);
 
   if (mode === 'image' && background) {
-    const bgWidth = (background as HTMLImageElement | ImageBitmap).width;
-    const bgHeight = (background as HTMLImageElement | ImageBitmap).height;
-    const imageRatio = bgWidth / bgHeight;
-    const canvasRatio = width / height;
-    let drawWidth = width;
-    let drawHeight = height;
-    let offsetX = 0;
-    let offsetY = 0;
-
-    if (imageRatio > canvasRatio) {
-      drawHeight = width / imageRatio;
-      offsetY = (height - drawHeight) / 2;
-    } else {
-      drawWidth = height * imageRatio;
-      offsetX = (width - drawWidth) / 2;
-    }
-    outputCtx.drawImage(background, offsetX, offsetY, drawWidth, drawHeight);
+    drawBackgroundImage(outputCtx, background, width, height);
   } else {
     outputCtx.filter = `blur(${BLUR_PX}px)`;
     outputCtx.drawImage(source, 0, 0, width, height);


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 관련된 이슈 번호를 작성하고, 자동으로 이슈를 닫으려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #335 

<br />

## ⏰ 작업 시간

> 예상 작업 시간과 실제 작업 시간을 작성해주세요.  
> 두 시간이 다를 경우, 그 이유를 함께 설명해주세요.

- 예상 작업 시간 : 1 h
- 실제 작업 시간 : 1 h

<br />

## 📝 작업 내용

> 이번 PR(작업)을 통해 수행한 주요 내용을 구체적으로 작성해주세요.

- 카메라를 껐다 켤 경우, 마스크가 준비되기 전까지 모드에 따라 다른 화면을 표시하도록 하였습니다:
  - 블러 모드: 전체 블러 → 배경만 블러
  - 이미지 모드: 배경 이미지만 → 배경 이미지 + 사람

<br />

> 관련된 스크린샷이나 캡처 화면을 첨부해주세요.

![2026-02-033 01 05-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/6ed11943-c676-4ca6-a1eb-9fdc4ec3fa57)


<br />

## 🪏 주요 고민과 해결 과정

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

### 발생 원인

[마스크가 생성 안된 경우 처리하는 부분]
```ts
if (mode === 'off' || !mask) {
  outputCtx.clearRect(0, 0, width, height);
  outputCtx.drawImage(source, 0, 0, width, height);  // 원본 그대로 출력
  return;
}
```
카메라를 껐다 켤 때 발생하는 순서:
1. `stop()` 호출 시 (카메라 끄면 호출) `resetCommonState()`에서 `latestMaskRef.current = null`로 초기화됨
2. `start()` 호출 시 (카메라 켜면 호출) 렌더링 루프는 즉시 시작되지만, Worker가 첫 번째 세그멘테이션 마스크를 생성하기까지 시간이 걸림
3. 그 사이에 `mask`가 `null`이므로 위 조건문에서 원본 영상이 그대로 출력됨
4. Worker에서 첫 마스크가 도착하면 그제서야 배경 효과가 적용됨

### 해결
 
작업 내용과 같습니다. 블러 모드의 경우 마스크 생성 전까지 전체 블러를 적용하였고, 이미지 모드의 경우 마스크 생성 전까지 기본 배경 이미지만 보이도록 하였습니다.

<br />

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 참고한 문서, 링크, 또는 외부 리소스를 작성해주세요.
