### PR TITLE
fix: 모니터링설정 수정

### DIFF
--- a/.github/deployments/monitoring/docker-compose.yml
+++ b/.github/deployments/monitoring/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - monitoring-network
 
   promtail:
-    image: grafana/promtail:2.9.0
+    image: grafana/promtail:3.0.0
     container_name: ${CONTAINER_PREFIX:-plum}-promtail
     restart: always
     volumes:

--- a/.github/deployments/monitoring/prometheus/prometheus-dev.yml
+++ b/.github/deployments/monitoring/prometheus/prometheus-dev.yml
@@ -34,9 +34,10 @@ scrape_configs:
   # 백엔드 애플리케이션 메트릭 (prom-client)
   - job_name: 'backend-app'
     static_configs:
-      - targets: ['BACKEND_HOST_PLACEHOLDER:3000']
+      - targets:
+BACKEND_TARGETS_PLACEHOLDER
         labels:
-          server: 'plum-dev'
+          server: 'plum-backend'
     metrics_path: '/metrics'
 
   # Redis 서버 시스템 메트릭 (Node Exporter)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -378,7 +378,25 @@ jobs:
             cp .github/deployments/monitoring/grafana/provisioning/alerting/policies.yml ./grafana/provisioning/alerting/policies.yml
 
             # Prometheus 설정 파일의 IP 플레이스홀더 치환
-            sed -i "s/BACKEND_HOST_PLACEHOLDER/${{ secrets.NCP_DEV_HOST }}/g" ./prometheus/prometheus.yml
+            # 백엔드 애플리케이션 타겟 생성
+            BACKEND_TARGETS=""
+            IFS=',' read -ra BACKEND_IPS <<< "${{ secrets.NCP_BACKEND_TARGETS }}"
+            for ip in "${BACKEND_IPS[@]}"; do
+              BACKEND_TARGETS="${BACKEND_TARGETS}          - '${ip}:3000'\n"
+            done
+            # 마지막 개행 제거, 앞에 공백 추가없게
+            BACKEND_TARGETS=$(echo -e "$BACKEND_TARGETS" | sed '$ s/\\n$//')
+
+            # 플레이스홀더를 targets 배열로 치환
+            awk -v targets="$BACKEND_TARGETS" '
+              /BACKEND_TARGETS_PLACEHOLDER/ {
+                print targets
+                next
+              }
+              { print }
+            ' ./prometheus/prometheus.yml > ./prometheus/prometheus.yml.tmp
+            mv ./prometheus/prometheus.yml.tmp ./prometheus/prometheus.yml
+
             sed -i "s/REDIS_HOST_PLACEHOLDER/${{ secrets.NCP_DEV_REDIS_HOST }}/g" ./prometheus/prometheus.yml
 
             # 환경 변수 설정
@@ -403,8 +421,29 @@ jobs:
             chown -R 472:472 grafana/data
             chmod -R 755 prometheus/data loki/data
 
-            # Prometheus 타겟 디렉토리 생성 (오토스케일링 서버 자동 등록용)
+            # Prometheus 타겟 디렉토리 생성 /백엔드 서버 등록 (오토스케일링 - 환경변수로 관리)
             mkdir -p /opt/prometheus/targets
+
+            # 환경변수에서 IP 목록을 읽어 JSON 생성
+            IFS=',' read -ra BACKEND_IPS <<< "${{ secrets.NCP_BACKEND_TARGETS }}"
+            echo "[" > /opt/prometheus/targets/backend.json
+            for i in "${!BACKEND_IPS[@]}"; do
+              ip="${BACKEND_IPS[$i]}"
+              echo "  {" >> /opt/prometheus/targets/backend.json
+              echo "    \"targets\": [\"${ip}:9100\"]," >> /opt/prometheus/targets/backend.json
+              echo "    \"labels\": {" >> /opt/prometheus/targets/backend.json
+              echo "      \"server\": \"plum-backend-$((i+1))\"," >> /opt/prometheus/targets/backend.json
+              echo "      \"ip\": \"${ip}\"" >> /opt/prometheus/targets/backend.json
+              echo "    }" >> /opt/prometheus/targets/backend.json
+              if [ $i -lt $((${#BACKEND_IPS[@]} - 1)) ]; then
+                echo "  }," >> /opt/prometheus/targets/backend.json
+              else
+                echo "  }" >> /opt/prometheus/targets/backend.json
+              fi
+            done
+            echo "]" >> /opt/prometheus/targets/backend.json
+
+            cat /opt/prometheus/targets/backend.json
 
             # 컨테이너 재시작
             docker compose pull

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -63,7 +63,7 @@ services:
 
   # Promtail - 로그 수집 및 Loki로 전송
   promtail:
-    image: grafana/promtail:2.9.0
+    image: grafana/promtail:3.0.0
     container_name: plum-backend-develop-promtail
     restart: unless-stopped
     volumes:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -112,7 +112,7 @@ services:
 
   # Promtail - 로그 수집 (백엔드 로그 → Loki)
   promtail:
-    image: grafana/promtail:2.9.0
+    image: grafana/promtail:3.0.0
     container_name: promtail-local
     volumes:
       - ./apps/backend/logs:/app/logs:ro

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -68,7 +68,7 @@ services:
 
   # Promtail - 로그 수집 및 Loki로 전송
   promtail:
-    image: grafana/promtail:2.9.0
+    image: grafana/promtail:3.0.0
     container_name: plum-backend-prod-promtail
     restart: always
     volumes:


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 관련된 이슈 번호를 작성하고, 자동으로 이슈를 닫으려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #383 

<br />

## ⏰ 작업 시간

> 예상 작업 시간과 실제 작업 시간을 작성해주세요.  
> 두 시간이 다를 경우, 그 이유를 함께 설명해주세요.

- 예상 작업 시간 :1h
- 실제 작업 시간 :1h

<br />

## 📝 작업 내용

> 이번 PR(작업)을 통해 수행한 주요 내용을 구체적으로 작성해주세요.
<img width="2280" height="360" alt="image" src="https://github.com/user-attachments/assets/69552b1d-c08b-49fd-b190-00a09c10c21c" />

**Promtail 버전 업그레이드 (2.9.0 → 3.0.0)**
- Docker API 버전 불일치로 로그 수집 실패
- 모든 docker-compose 파일에서 Promtail 이미지 업데이트
- cd 파일 수정으로 단일 서버로만 가는 상황에서 여러 서버의 정보를 수집할수 있도록 수정했습니다.
- 프로메테우스설정은  메트릭(port 3000)도 모든 서버에서 수집하도록 설정

**오토스케일링 백엔드 서버 동적 모니터링 지원**
- 문제: 기존에는 단일 백엔드 서버만 모니터링 가능
- 해결:환경변수 `NCP_BACKEND_TARGETS`로 여러 서버를 동적으로 관리
- CD 워크플로우에서 콤마로 구분된 IP 목록을 Prometheus 타겟으로 자동 변환
- Prometheus가 살아있는 서버만 자동 수집 (`up=1`/`up=0`)


**Grafana 대시보드 로그 쿼리 수정**
- Loki 쿼리를 {container=~".+"} → {job="plum-backend"}로 변경
- 백엔드 파일 로그 수집 방식에 맞게

<br />

> 관련된 스크린샷이나 캡처 화면을 첨부해주세요.

<br />

## 🪏 주요 고민과 해결 과정

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.


<br />

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 참고한 문서, 링크, 또는 외부 리소스를 작성해주세요.
