### PR TITLE
fix: 방 초기화 시 전역 상태 정리 로직 추가

### DIFF
--- a/apps/frontend/src/feature/room/hooks/useRoomInit.ts
+++ b/apps/frontend/src/feature/room/hooks/useRoomInit.ts
@@ -1,16 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+
 import { SocketClient } from '@/shared/socket/socket';
 import { MediaConnectionService } from '@/mediasoup/mediaConnection.service';
-import { useRoomJoin } from './useRoomJoin';
-import { useRoomEventHandlers } from './useRoomEventHandlers';
-import { useRemoteMedia } from './useRemoteMedia';
-import { useMediaCleanup } from './useMediaCleanup';
-import { useInteractionSync } from './useInteractionSync';
 import { useSafeRoomId } from '@/shared/hooks/useSafeRoomId';
 import { roomApi } from '@/shared/api';
-
-import { useRoomStore } from '../stores/useRoomStore';
 import { logger } from '@/shared/lib/logger';
+
+import { useChatStore } from '../stores/useChatStore';
+import { usePollStore } from '../stores/usePollStore';
+import { useRoomStore } from '../stores/useRoomStore';
+import { useRoomEventHandlers } from './useRoomEventHandlers';
+import { useInteractionSync } from './useInteractionSync';
+import { useRemoteMedia } from './useRemoteMedia';
+import { useMediaCleanup } from './useMediaCleanup';
+import { useRoomJoin } from './useRoomJoin';
+import { useRoomUIStore } from '../stores/useRoomUIStore';
 
 /**
  * 방 입장 시 전체 초기화 파이프라인을 실행하는 훅
@@ -35,13 +39,18 @@ import { logger } from '@/shared/lib/logger';
  * - isError: 초기화 실패 여부 (에러 토스트 표시용)
  */
 export function useRoomInit(handleInitialMedia: () => Promise<void>) {
+  const roomId = useSafeRoomId();
+  const hasStarted = useRef(false);
+
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isError, setIsError] = useState(false);
 
-  const roomId = useSafeRoomId();
-  const hasStarted = useRef(false);
   const myInfo = useRoomStore((state) => state.myInfo);
+  const chatActions = useChatStore((state) => state.actions);
+  const pollActions = usePollStore((state) => state.actions);
+  const roomActions = useRoomStore((state) => state.actions);
+  const roomUIReset = useRoomUIStore((state) => state.reset);
 
   const { joinRoom } = useRoomJoin();
   const { consumeExistingProducers } = useRemoteMedia();
@@ -126,8 +135,12 @@ export function useRoomInit(handleInitialMedia: () => Promise<void>) {
   useEffect(() => {
     return () => {
       cleanupMedia();
+      chatActions.clear();
+      pollActions.clear();
+      roomActions.reset();
+      roomUIReset();
     };
-  }, [cleanupMedia]);
+  }, [cleanupMedia, chatActions, pollActions, roomActions, roomUIReset]);
 
   return { isLoading, isSuccess, isError };
 }

--- a/apps/frontend/src/feature/room/stores/usePollStore.ts
+++ b/apps/frontend/src/feature/room/stores/usePollStore.ts
@@ -19,6 +19,7 @@ interface PollState {
     updatePollDetail: (data: UpdatePollStatusFullPayload) => void;
     setCompletedFromEndDetail: (data: EndPollDetailPayload) => void;
     setAudienceVotedOption: (pollId: string, optionId: number | null) => void;
+    clear: () => void;
   };
 }
 
@@ -162,6 +163,9 @@ export const usePollStore = create<PollState>((set) => ({
           [pollId]: optionId,
         },
       }));
+    },
+    clear: () => {
+      set({ polls: [], audienceVotedOptionByPollId: {} });
     },
   },
 }));

--- a/apps/frontend/src/feature/room/stores/useRoomUIStore.ts
+++ b/apps/frontend/src/feature/room/stores/useRoomUIStore.ts
@@ -11,6 +11,7 @@ interface RoomUIState {
   setActiveDialog: (dialog: Dialog) => void;
   setActiveSidePanel: (panel: SidePanel) => void;
   setPollResult: (result: EndPollPayload | null) => void;
+  reset: () => void;
 }
 
 const initialState: Pick<RoomUIState, 'activeDialog' | 'activeSidePanel' | 'pollResult'> = {
@@ -30,4 +31,5 @@ export const useRoomUIStore = create<RoomUIState>((set) => ({
       activeSidePanel: state.activeSidePanel === panel ? null : panel,
     })),
   setPollResult: (result) => set({ pollResult: result }),
+  reset: () => set({ ...initialState }),
 }));


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 관련된 이슈 번호를 작성하고, 자동으로 이슈를 닫으려면 `Closes #이슈번호` 형식으로 작성해주세요.

- Closes #401 

<br />

## ⏰ 작업 시간

> 예상 작업 시간과 실제 작업 시간을 작성해주세요.  
> 두 시간이 다를 경우, 그 이유를 함께 설명해주세요.

- 예상 작업 시간 : 0.5 h
- 실제 작업 시간 : 0.5 h

<br />

## 📝 작업 내용

> 이번 PR(작업)을 통해 수행한 주요 내용을 구체적으로 작성해주세요.

- 강의실에서 사용되는 전역 스토어들을 cleanup에 등록했습니다.
- 강의실 페이지에서 벗어날 시, 전역 스토어가 초기화됩니다.

<br />

> 관련된 스크린샷이나 캡처 화면을 첨부해주세요.

<br />

## 🪏 주요 고민과 해결 과정

> 작업 중 겪은 문제나 고민, 그리고 그에 대한 해결 과정을 정리해주세요.  
> 관련 트러블슈팅 문서가 있다면 링크로 연결해주세요.

-

<br />

## 💬 리뷰 요구사항

> 리뷰어가 중점적으로 확인해주길 바라는 부분이 있다면 작성해주세요.

<br />

## 📘 참고 자료

> 참고한 문서, 링크, 또는 외부 리소스를 작성해주세요.
